### PR TITLE
Chromeでページ初期読み込み時に、一瞬メニューがちらつく現象対応

### DIFF
--- a/css/style.css
+++ b/css/style.css
@@ -32,6 +32,12 @@ a {
   box-sizing: border-box;
 }
 
+/* load ※Chromeのページ初期読み込み時のtransition抑制対応 */
+
+.js-preload * {
+  transition: none !important;
+}
+
 /* layout */
 
 html {
@@ -77,6 +83,10 @@ a:not(.nav-list__link-active)::after {
 a:not(.nav-list__item-active):hover::after {
   transform: scale(1, 2);
   transform-origin: left top;
+}
+
+.js-overflow-hidden {
+  overflow: hidden;
 }
 
 .container {
@@ -313,7 +323,7 @@ a:not(.nav-list__item-active):hover::after {
   margin-bottom: 0;
 }
 
-.menu--open {
+.js-menu--open {
   visibility: visible;
   opacity: 100%;
   transition-delay: 0s;

--- a/index.html
+++ b/index.html
@@ -28,7 +28,7 @@
       rel="stylesheet"
     />
   </head>
-  <body>
+  <body class="js-preload">
     <div id="contents" class="contents">
       <header class="top-header">
         <div class="container top-header__layout">

--- a/js/main.js
+++ b/js/main.js
@@ -8,18 +8,18 @@ const menu = document.getElementById('menu');
  * メニューを開く
  */
 const openMenu = () => {
-  menu.classList.add('menu--open');
+  menu.classList.add('js-menu--open');
   contents.setAttribute('inert', true);
-  document.body.classList.add('overflow-hidden');
+  document.body.classList.add('js-overflow-hidden');
 };
 
 /**
  * メニューを閉じる
  */
 const closeMenu = () => {
-  menu.classList.remove('menu--open');
+  menu.classList.remove('js-menu--open');
   contents.removeAttribute('inert', false);
-  document.body.classList.remove('overflow-hidden');
+  document.body.classList.remove('js-overflow-hidden');
 };
 
 window.addEventListener('DOMContentLoaded', () => {
@@ -29,4 +29,11 @@ window.addEventListener('DOMContentLoaded', () => {
 
   const menuCloseBtn = document.getElementById('close-menu-btn');
   menuCloseBtn.addEventListener('click', closeMenu);
+});
+
+window.addEventListener('load', () => {
+  // Chromeでページ初期読み込み時のtrasition抑制クラスの除去
+  document
+    .getElementsByClassName('js-preload')[0]
+    .classList.remove('js-preload');
 });


### PR DESCRIPTION
## Issue 番号
closes #11 

## 対応内容
- Chromeでページ初期読み込み時に、一瞬メニューがちらつく現象対応
（あらかじめ trasition を抑制するスタイルのクラスを付与しておき、ページ読み込み後に除去するようにした）