### PR TITLE
 type moduleにしたことでPostCSSの設定ファイルも.mjs方式に移行

### DIFF
--- a/postcss.config.js
+++ b/postcss.config.js
@@ -1,3 +1,0 @@
-module.exports = {
-  plugins: [require('postcss-preset-env')],
-};

--- a/postcss.config.mjs
+++ b/postcss.config.mjs
@@ -1,0 +1,5 @@
+export default {
+  plugins: {
+    'postcss-preset-env': {},
+  },
+};


### PR DESCRIPTION
## Issue 番号
<!-- ※マージとともクローズの場合は closes をつける -->
#17 

## 対応内容
- PostCSS の設定ファイルを postcss.config.mjs へ移行
  - これをやっていなかったので、ビルド時にエラーになってしまう状態だった。